### PR TITLE
Implemented native clipboard passthrough support

### DIFF
--- a/cmd/bore/app/app.go
+++ b/cmd/bore/app/app.go
@@ -2,8 +2,6 @@ package app
 
 import (
 	"database/sql"
-	"fmt"
-	"os"
 
 	"go.trulyao.dev/bore/pkg/config"
 	"go.trulyao.dev/bore/pkg/daos"
@@ -35,7 +33,7 @@ func New(configPath string) (*App, error) {
 	}
 	a.db = db
 
-	a.loadNativeClipboard()
+	a.nativeClipboard, _ = system.NewNativeClipboard()
 
 	return a, nil
 }
@@ -49,14 +47,6 @@ func (a *App) Handler() handler.HandlerInterface {
 }
 
 func (a *App) loadNativeClipboard() {
-	a.nativeClipboard, _ = system.NewNativeClipboard()
-
-	if !a.nativeClipboard.IsAvailable() {
-		fmt.Fprint(
-			os.Stderr,
-			"[WARNING] Native clipbaord passthrough is enabled but no clipboard was found on this system",
-		)
-	}
 }
 
 func (a *App) UpdateConfigPath(configPath string) error {
@@ -72,7 +62,7 @@ func (a *App) UpdateConfigPath(configPath string) error {
 		return err
 	}
 
-	a.loadNativeClipboard()
+	a.nativeClipboard, _ = system.NewNativeClipboard()
 
 	return nil
 }

--- a/cmd/bore/app/config.go
+++ b/cmd/bore/app/config.go
@@ -73,6 +73,11 @@ func (a *App) DumpCurrentConfig(ctx *cli.Context) error {
 		"%t",
 		a.nativeClipboard.IsAvailable(),
 	)
+	props["Native clipboard paths"] = fmt.Sprintf(
+		"Copy: %s, Paste: %s",
+		a.nativeClipboard.Paths().CopyBinPath,
+		a.nativeClipboard.Paths().PasteBinPath,
+	)
 
 	var output string
 	for key, value := range props {

--- a/cmd/bore/app/config.go
+++ b/cmd/bore/app/config.go
@@ -58,12 +58,26 @@ func (a *App) DumpCurrentConfig(ctx *cli.Context) error {
 		return nil
 	}
 
-	output := fmt.Sprintf(`Loaded configuration from %s
-DataDir: %s
-EnableNativeClipboard: %t
-ShowIdOnCopy: %t
-`,
-		a.config.Path, a.config.DataDir, a.config.EnableNativeClipboard, a.config.ShowIdOnCopy)
+	props := map[string]string{}
+	props["Config path"] = a.config.Path
+	props["Data directory"] = a.config.DataDir
+	props["Enable native clipboard passthrough directory"] = fmt.Sprintf(
+		"%t",
+		a.config.EnableNativeClipboard,
+	)
+	props["Show ID on copy"] = fmt.Sprintf(
+		"%t",
+		a.config.ShowIdOnCopy,
+	)
+	props["Native clipboard is present"] = fmt.Sprintf(
+		"%t",
+		a.nativeClipboard.IsAvailable(),
+	)
+
+	var output string
+	for key, value := range props {
+		output += "- " + key + ": " + value + "\n"
+	}
 
 	fmt.Fprintf(ctx.App.Writer, "%s", output)
 	return nil

--- a/cmd/bore/app/handler.go
+++ b/cmd/bore/app/handler.go
@@ -37,10 +37,11 @@ func (a *App) PasteCommand() *cli.Command {
 
 		// TODO: Add flags for: last ranges of copied content, file to write to, collection to paste from etc.
 		Flags: []cli.Flag{
+			// TODO: implement format support for pasting
 			&cli.StringFlag{
 				Name:    "format",
 				Aliases: []string{"f"},
-				Usage:   "The format of the content to copy. Available formats: base64, plain-text",
+				Usage:   "The format to paste the content in. Available formats: base64, plain-text",
 				Value:   handler.FormatPlainText,
 			},
 			&cli.BoolFlag{
@@ -119,7 +120,11 @@ func (a *App) CopyFromStdin(ctx *cli.Context) (io.Reader, error) {
 	return bufio.NewReader(ctx.App.Reader), nil
 }
 
+// Paste handles the paste command
 func (a *App) Paste(ctx *cli.Context) error {
-	err := a.Handler().PasteLastCopied(ctx.App.Writer)
-	return err
+	if ctx.Bool("from-system") {
+		return a.Handler().PasteFromSystemClipboard(ctx.App.Writer)
+	}
+
+	return a.Handler().PasteLastCopied(ctx.App.Writer)
 }

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -6,9 +6,12 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"os"
 	"time"
 
+	"go.trulyao.dev/bore/pkg/config"
 	"go.trulyao.dev/bore/pkg/daos"
+	"go.trulyao.dev/bore/pkg/system"
 )
 
 const (
@@ -36,11 +39,17 @@ type HandlerInterface interface {
 }
 
 type Handler struct {
-	dao *daos.Queries
+	dao             *daos.Queries
+	config          *config.Config
+	nativeClipboard system.NativeClipboardInterface
 }
 
-func New(dao *daos.Queries) *Handler {
-	return &Handler{dao: dao}
+func New(
+	dao *daos.Queries,
+	config *config.Config,
+	nativeClipboard system.NativeClipboardInterface,
+) *Handler {
+	return &Handler{dao: dao, config: config, nativeClipboard: nativeClipboard}
 }
 
 // Copy copies the content of the reader to the database and returns the ID of the content
@@ -59,17 +68,36 @@ func (h *Handler) Copy(r io.Reader, opts CopyOpts) (string, error) {
 	}
 
 	// Check if the content already exists, if it does, just update the last modified time
-	// TODO: write to the native clipboard regardless if enabled
-	ctx, _ := context.WithTimeout(context.TODO(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+	defer cancel()
 
 	createArtifactParams := daos.UpsertArtifactParams{Content: content}
 	if opts.CollectionId != "" {
 		createArtifactParams.CollectionID = sql.NullString{String: opts.CollectionId, Valid: true}
 	}
 
+	// Persist to main store
 	artifact, err := h.dao.UpsertArtifact(ctx, createArtifactParams)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("Failed to write to bore store: %s", err.Error())
+	}
+
+	// Write to native clipboard if enabled and present
+	if h.config.EnableNativeClipboard {
+		if !h.nativeClipboard.IsAvailable() {
+			fmt.Fprint(
+				os.Stderr,
+				"[WARNING] `EnableNativeClipboard` is set to true in your config but no native clipboard was found on this machine",
+			)
+			return artifact.ID, nil
+		}
+
+		if err = h.nativeClipboard.Copy(content); err != nil {
+			return artifact.ID, fmt.Errorf(
+				"Copied to bore store but failed to write to native clipboard: %s",
+				err.Error(),
+			)
+		}
 	}
 
 	return artifact.ID, nil

--- a/pkg/system/clipboard.go
+++ b/pkg/system/clipboard.go
@@ -1,5 +1,10 @@
 package system
 
+type ProgramPaths struct {
+	CopyBinPath  string
+	PasteBinPath string
+}
+
 // NativeClipboard is the interface for interacting with the underlying clipboard
 type NativeClipboardInterface interface {
 	// IsAvailable checks if a native system clipboard is available
@@ -10,4 +15,7 @@ type NativeClipboardInterface interface {
 
 	// Paste returns the last copied content from the system clipboard
 	Paste() ([]byte, error)
+
+	// Paths returns the programs used for copying and pasting
+	Paths() ProgramPaths
 }

--- a/pkg/system/clipboard_darwin.go
+++ b/pkg/system/clipboard_darwin.go
@@ -41,7 +41,7 @@ func (n *nativeClipboard) IsAvailable() bool {
 
 // Copy copies the content to the system clipboard
 func (n *nativeClipboard) Copy(content []byte) error {
-	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, n.copyBinPath)

--- a/pkg/system/clipboard_darwin.go
+++ b/pkg/system/clipboard_darwin.go
@@ -1,26 +1,62 @@
-//go:build darwin
-
 package system
 
-type nativeClipboard struct{}
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"time"
+)
+
+type nativeClipboard struct {
+	// Path to `pbcopy`
+	copyBinPath string
+
+	// Path to `pbpaste`
+	pasteBinPath string
+}
 
 func NewNativeClipboard() (NativeClipboardInterface, error) {
-	return &nativeClipboard{}, nil
+	var err error
+
+	n := new(nativeClipboard)
+
+	n.copyBinPath, err = exec.LookPath("pbcopy")
+	if n.copyBinPath == "" || err != nil {
+		return n, errors.New("`pbcopy` not available")
+	}
+
+	n.pasteBinPath, err = exec.LookPath("pbpaste")
+	if n.pasteBinPath == "" || err != nil {
+		return n, errors.New("`pbpaste` not available")
+	}
+
+	return n, nil
 }
 
 // IsAvailable checks if a clipboard is available on the current system
 func (n *nativeClipboard) IsAvailable() bool {
-	panic("not implemented")
+	return (n.copyBinPath != "" && n.pasteBinPath != "")
 }
 
 // Copy copies the content to the system clipboard
 func (n *nativeClipboard) Copy(content []byte) error {
-	panic("not implemented")
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, n.copyBinPath)
+	cmd.Stdin = bytes.NewReader(content)
+
+	return cmd.Run()
 }
 
 // Paste returns the last copied content from the system clipboard
 func (n *nativeClipboard) Paste() ([]byte, error) {
-	panic("not implemented")
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, n.pasteBinPath)
+	return cmd.Output()
 }
 
 var _ NativeClipboardInterface = (*nativeClipboard)(nil)

--- a/pkg/system/clipboard_darwin.go
+++ b/pkg/system/clipboard_darwin.go
@@ -59,4 +59,12 @@ func (n *nativeClipboard) Paste() ([]byte, error) {
 	return cmd.Output()
 }
 
+// Paths returns the programs used for copying and pasting
+func (n *nativeClipboard) Paths() ProgramPaths {
+	return ProgramPaths{
+		CopyBinPath:  n.copyBinPath,
+		PasteBinPath: n.pasteBinPath,
+	}
+}
+
 var _ NativeClipboardInterface = (*nativeClipboard)(nil)

--- a/pkg/system/clipboard_linux.go
+++ b/pkg/system/clipboard_linux.go
@@ -73,7 +73,7 @@ func (n *nativeClipboard) IsAvailable() bool {
 
 // Copy copies the content to the system clipboard
 func (n *nativeClipboard) Copy(content []byte) error {
-	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, n.copyBinPath)

--- a/pkg/system/clipboard_linux.go
+++ b/pkg/system/clipboard_linux.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package system
 
 type nativeClipboard struct {
@@ -7,12 +5,14 @@ type nativeClipboard struct {
 }
 
 func NewNativeClipboard() (NativeClipboardInterface, error) {
+	// TODO: look for all common clipbaord managers on linux
+	// xclip | xsel | (wl-copy & wl-paste)
 	panic("not implemented")
 }
 
 // IsAvailable checks if a clipboard is available on the current system
 func (n *nativeClipboard) IsAvailable() bool {
-	panic("not implemented")
+	return n.binName != ""
 }
 
 // Copy copies the content to the system clipboard

--- a/pkg/system/clipboard_linux.go
+++ b/pkg/system/clipboard_linux.go
@@ -1,28 +1,107 @@
 package system
 
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"time"
+)
+
+type ProgramType int
+
+const (
+	ProgXclip = iota
+	ProgXsel
+	ProgWlClipboard
+)
+
 type nativeClipboard struct {
-	binName string
+	// Clipboard program type
+	program ProgramType
+
+	// Path to the binary responsible for copying
+	copyBinPath string
+
+	// Path to the binary responsible for pasting
+	pasteBinPath string
 }
 
 func NewNativeClipboard() (NativeClipboardInterface, error) {
-	// TODO: look for all common clipbaord managers on linux
-	// xclip | xsel | (wl-copy & wl-paste)
-	panic("not implemented")
+	n := new(nativeClipboard)
+	var (
+		path string
+		err  error
+	)
+
+	// Check for `xclip`
+	if path, err = exec.LookPath("xclip"); err == nil {
+		n.copyBinPath = path
+		n.pasteBinPath = path
+		n.program = ProgXclip
+		return n, nil
+	}
+
+	// Check for `xsel`
+	if path, err = exec.LookPath("xsel"); err == nil {
+		n.copyBinPath = path
+		n.pasteBinPath = path
+		n.program = ProgXsel
+		return n, nil
+	}
+
+	// Check for `wl-clipboard`
+	// For this, we need to check for the presence of both binaries: wl-copy and wc-paste
+	wlCopyPath, wcerr := exec.LookPath("wl-copy")
+	wlPastePath, wperr := exec.LookPath("wl-paste")
+	if (wlCopyPath != "" && wcerr == nil) && (wlPastePath != "" && wperr == nil) {
+		n.copyBinPath = wlCopyPath
+		n.pasteBinPath = wlPastePath
+		n.program = ProgWlClipboard
+		return n, nil
+	}
+
+	return n, errors.New(
+		"no supported clipboard found, the following are currently supported: `xclip`, `xsel` and `wl-clipboard`",
+	)
 }
 
 // IsAvailable checks if a clipboard is available on the current system
 func (n *nativeClipboard) IsAvailable() bool {
-	return n.binName != ""
+	return (n.copyBinPath != "" && n.pasteBinPath != "")
 }
 
 // Copy copies the content to the system clipboard
 func (n *nativeClipboard) Copy(content []byte) error {
-	panic("not implemented")
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, n.copyBinPath)
+	cmd.Stdin = bytes.NewReader(content)
+
+	return cmd.Run()
 }
 
 // Paste returns the last copied content from the system clipboard
 func (n *nativeClipboard) Paste() ([]byte, error) {
-	panic("not implemented")
+	opts := []string{}
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+	defer cancel()
+
+	if n.program == ProgXclip {
+		opts = []string{"-o"}
+	}
+
+	cmd := exec.CommandContext(ctx, n.pasteBinPath, opts...)
+	return cmd.Output()
+}
+
+func (n *nativeClipboard) Paths() ProgramPaths {
+	return ProgramPaths{
+		CopyBinPath:  n.copyBinPath,
+		PasteBinPath: n.pasteBinPath,
+	}
 }
 
 var _ NativeClipboardInterface = (*nativeClipboard)(nil)

--- a/pkg/system/clipboard_windows.go
+++ b/pkg/system/clipboard_windows.go
@@ -40,7 +40,7 @@ func (n *nativeClipboard) IsAvailable() bool {
 
 // Copy copies the content to the system clipboard
 func (n *nativeClipboard) Copy(content []byte) error {
-	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, n.copyBinPath)

--- a/pkg/system/clipboard_windows.go
+++ b/pkg/system/clipboard_windows.go
@@ -1,24 +1,68 @@
 package system
 
-type nativeClipboard struct{}
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+type nativeClipboard struct {
+	// Path to the binary responsible for copying
+	copyBinPath string
+
+	// Path to the binary responsible for pasting
+	pasteBinPath string
+}
 
 func NewNativeClipboard() (NativeClipboardInterface, error) {
+	var err error
+	n := new(nativeClipboard)
+
+	n.copyBinPath, err = exec.LookPath("clip.exe")
+	if n.copyBinPath == "" || err != nil {
+		return n, fmt.Errorf("failed to find clip.exe: %s", err.Error())
+	}
+
+	n.pasteBinPath, err = exec.LookPath("powershell.exe")
+	if n.pasteBinPath == "" || err != nil {
+		return n, fmt.Errorf("failed to find powershell.exe: %s", err.Error())
+	}
+
 	return &nativeClipboard{}, nil
 }
 
 // IsAvailable checks if a clipboard is available on the current system
 func (n *nativeClipboard) IsAvailable() bool {
-	panic("not implemented")
+	return n.copyBinPath != "" && n.pasteBinPath != ""
 }
 
 // Copy copies the content to the system clipboard
 func (n *nativeClipboard) Copy(content []byte) error {
-	panic("not implemented")
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, n.copyBinPath)
+	cmd.Stdin = bytes.NewReader(content)
+
+	return cmd.Run()
 }
 
 // Paste returns the last copied content from the system clipboard
 func (n *nativeClipboard) Paste() ([]byte, error) {
-	panic("not implemented")
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, n.pasteBinPath, "Get-Clipboard")
+	return cmd.Output()
+}
+
+func (n *nativeClipboard) Paths() ProgramPaths {
+	return ProgramPaths{
+		CopyBinPath:  n.copyBinPath,
+		PasteBinPath: n.pasteBinPath,
+	}
 }
 
 var _ NativeClipboardInterface = (*nativeClipboard)(nil)

--- a/pkg/system/clipboard_windows.go
+++ b/pkg/system/clipboard_windows.go
@@ -1,5 +1,3 @@
-//go:build windows
-
 package system
 
 type nativeClipboard struct{}

--- a/sql/migrations/migrations.go
+++ b/sql/migrations/migrations.go
@@ -3,6 +3,8 @@ package migrations
 import (
 	"embed"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/sqlite3"
@@ -47,10 +49,12 @@ func Migrate(databasePath string) error {
 		return fmt.Errorf("failed to create source driver: %w", err)
 	}
 
+	dsn := "sqlite3:" + strings.Repeat(string(os.PathSeparator), 2) + databasePath
+
 	migrator, err := migrate.NewWithSourceInstance(
 		"iofs",
 		sourceDriver,
-		"sqlite3://"+databasePath,
+		dsn,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create migrator: %w", err)


### PR DESCRIPTION
- **Refactored config to use maps for entries**
- **Updated stubs**
- **Added base support for native clipboards in copy op**
- **Added macos clipboard implementation**
- **Don't warn about native clipboard on bare run**
- **Added clipboard support for Linux (xclip, xsel and wl-clipboard)**
- **Fixed path separator bug**
- **Added support for pasting from system clipboard**
- **Added clipboard support for windows (untested)**
