### PR TITLE
Load config in current directory

### DIFF
--- a/cmd/bore/app/config.go
+++ b/cmd/bore/app/config.go
@@ -65,7 +65,7 @@ func (a *App) DumpCurrentConfig(ctx *cli.Context) error {
 
 	columns := []table.Column{
 		{Title: "Property", Width: 30},
-		{Title: "Value", Width: 12},
+		{Title: "Value", Width: 14},
 		{Title: "Description", Width: 16},
 	}
 


### PR DESCRIPTION
When there is a config file at `bore.toml` or `.bore/config.toml`, load that unless the user provided a config path to use.
